### PR TITLE
Bring back Exchange2

### DIFF
--- a/configs/common.mk
+++ b/configs/common.mk
@@ -45,6 +45,10 @@ PRODUCT_PACKAGES += \
     AicpExtras \
     Screencast
 
+# Exchange support
+PRODUCT_PACKAGES += \
+    Exchange2
+
 # Extra tools in AICP
 PRODUCT_PACKAGES += \
     7z \


### PR DESCRIPTION
Dropped out via r22, but we want this

Change-Id: Id8b476dc26a48262925c351764dd3fdf2cf9adf3