### PR TITLE
Add Weather Content Provider [3/5]

### DIFF
--- a/configs/cmsdk_common.mk
+++ b/configs/cmsdk_common.mk
@@ -7,7 +7,8 @@ PRODUCT_COPY_FILES += \
     vendor/aicp/configs/permissions/org.cyanogenmod.appsuggest.xml:system/etc/permissions/org.cyanogenmod.appsuggest.xml \
     vendor/aicp/configs/permissions/org.cyanogenmod.telephony.xml:system/etc/permissions/org.cyanogenmod.telephony.xml \
     vendor/aicp/configs/permissions/org.cyanogenmod.performance.xml:system/etc/permissions/org.cyanogenmod.performance.xml \
-    vendor/aicp/configs/permissions/org.cyanogenmod.partner.xml:system/etc/permissions/org.cyanogenmod.partner.xml
+    vendor/aicp/configs/permissions/org.cyanogenmod.partner.xml:system/etc/permissions/org.cyanogenmod.partner.xml \
+    vendor/aicp/configs/permissions/org.cyanogenmod.weather.xml:system/etc/permissions/org.cyanogenmod.weather.xml
 
 # CM Platform Library
 PRODUCT_PACKAGES += \

--- a/configs/common.mk
+++ b/configs/common.mk
@@ -44,7 +44,8 @@ PRODUCT_PACKAGES += \
     ExactCalculator \
     AicpExtras \
     Screencast \
-    LiveLockScreenService
+    LiveLockScreenService \
+    WeatherProvider
 
 # Exchange support
 PRODUCT_PACKAGES += \

--- a/configs/permissions/org.cyanogenmod.weather.xml
+++ b/configs/permissions/org.cyanogenmod.weather.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2016 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<permissions>
+    <feature name="org.cyanogenmod.weather" />
+</permissions>

--- a/sepolicy/service.te
+++ b/sepolicy/service.te
@@ -12,3 +12,4 @@ type cm_performance_service, system_api_service, system_server_service, service_
 type cm_themes_service, system_api_service, system_server_service, service_manager_type;
 type cm_iconcache_service, system_api_service, system_server_service, service_manager_type;
 type cm_livelockscreen_service, system_api_service, system_server_service, service_manager_type;
+type cm_weather_service, system_api_service, system_server_service, service_manager_type;

--- a/sepolicy/service_contexts
+++ b/sepolicy/service_contexts
@@ -12,3 +12,4 @@ cmperformance                             u:object_r:cm_performance_service:s0
 cmthemes                                  u:object_r:cm_themes_service:s0
 cmiconcache                               u:object_r:cm_iconcache_service:s0
 cmlivelockscreen                          u:object_r:cm_livelockscreen_service:s0
+cmweather                                 u:object_r:cm_weather_service:s0


### PR DESCRIPTION
Introduce the weather system feature, which will be used to
identify if the Weather Content Provider/Weather services are
available in the device.

Add SELinux entries for the cmweather service

Change-Id: Ibe862903095276f87f23c0d7dae54733eeeb5638